### PR TITLE
Trying to make requirements less noisy

### DIFF
--- a/R/hello.R
+++ b/R/hello.R
@@ -223,7 +223,7 @@ text_stats_fn_ <- function(text){
   text <- prep_text(text)
 
 
-  require("koRpus.lang.en")
+  require("koRpus.lang.en", quietly = TRUE)
 
   # stringi methods
   n_char_tot <- sum(stri_stats_latex(text)[c(1,3)])

--- a/R/hello.R
+++ b/R/hello.R
@@ -207,7 +207,6 @@ prep_text <- function(text){
 }
 
 prep_text_korpus <- function(text){
-  requireNamespace("koRpus.lang.en")
   tokenize_safe <- purrr::safely(koRpus::tokenize)
   k1 <- tokenize_safe(text, lang = 'en', format = 'obj')
   k1 <- k1$result
@@ -224,10 +223,7 @@ text_stats_fn_ <- function(text){
   text <- prep_text(text)
 
 
-  requireNamespace("stringi")
-  requireNamespace("koRpus")
   require("koRpus.lang.en")
-  requireNamespace("sylly")
 
   # stringi methods
   n_char_tot <- sum(stri_stats_latex(text)[c(1,3)])
@@ -287,8 +283,6 @@ readability_fn_ <- function(text){
 
   oldw <- getOption("warn")
   options(warn = -1)
-
- requireNamespace("koRpus")
 
   # korpus methods
   k1 <- prep_text_korpus(text)


### PR DESCRIPTION
I'm not sure how to reduce the noise from koRpus.lang.en:

```

Attaching package: ‘sylly’

The following object is masked from ‘package:testthat’:

    describe

For information on available language packages for 'koRpus', run

  available.koRpus.lang()

and see ?install.koRpus.lang()


Attaching package: ‘koRpus’

The following object is masked from ‘package:wordcountaddin’:

    readability
```

That really needs to be fixed upstream