### PR TITLE
Prioritize selected text over this_filename()

### DIFF
--- a/tests/testthat/test_wordcountaddin.R
+++ b/tests/testthat/test_wordcountaddin.R
@@ -258,6 +258,14 @@ test_that("don't count abbreviations as multiple words", {
 
 })
 
+test_that("text_to_count reads file contents as character vector", {
+  contents <- text_to_count(test_path("test_wordcountaddin.Rmd"))
 
+  expect_type(contents, "character")
+  expect_length(contents, 1)
+})
 
+test_that("text_to_count raises an error for invalid file types", {
+  expect_error(text_to_count("invalid.tif"), regexp = "works with markdown")
+})
 


### PR DESCRIPTION
This commit fixes an issue (#26) where word counts for entire files were always generated, regardless of whether text was selected. Now, selected text takes precedence, which I believe re-aligns the behavior of the add-on with the description in the README.

Also, this commit adds some tests for the modified function. I tried to write tests to ensure that selected text is counted, but failed (apparently, when running tests in RStudio using the Test Package button or Ctrl+Shift+T, the rstudioapi package is not by default enabled). It may be possible to conditionally skip some tests, as is done in the tests for the rstudioapi package (https://github.com/rstudio/rstudioapi/blob/master/tests/testthat/test-document-apis.R#L15).

Tagging @benmarwick for a review!