### PR TITLE
fixed YAML detection and exclusion

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -9,3 +9,4 @@
 ^wordcountaddin\.Rcheck$
 ^wordcountaddin.*\.tar\.gz$
 ^wordcountaddin.*\.tgz$
+.github/

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,7 +13,10 @@ Authors@R: c(person("Ben", "Marwick",
                   role = "ctb"),
             person("Florian S.", "Schaffner",
                   email = "florian.schaffner@outlook.com",
-                  role = "ctb"))
+                  role = "ctb"),
+            person("Matthew T.", "Warkentin",
+                   email = "warkentin@lunenfeld.ca",
+                   role = "ctb"))
 Maintainer: Ben Marwick <benmarwick@gmail.com>
 Description: An addin for RStudio that will count the words and characters
     in a plain text document. It is designed for use with RMarkdown

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -35,7 +35,7 @@ Imports:
     sylly,
     sylly.en
 Encoding: UTF-8
-RoxygenNote: 6.1.1
+RoxygenNote: 7.0.2
 Suggests:
     covr,
     testthat

--- a/R/hello.R
+++ b/R/hello.R
@@ -69,6 +69,7 @@ word_count <- function(filename = this_filename()){
 
 #' @rdname text_stats
 #' @description Get readability stats for selected text (excluding code chunks)
+#' @param quiet Logical. Should task be performed quietly?
 #'
 #' @details Call this addin to get readbility stats about the text
 #'
@@ -149,8 +150,14 @@ prep_text <- function(text){
   # remove all line breaks, http://stackoverflow.com/a/21781150/1036500
   text <- gsub("[\r\n]", " ", text)
 
-  # don't include front yaml
-  text <- gsub("^---.*^--- ", "", text) # make sure we only match when backticks are at the start of the line
+  # don't include yaml front matter
+  three_dashes <- unlist(gregexpr('---', text))
+  if (three_dashes[1]==1L) {
+    yaml_end <- three_dashes[2] + 2L
+    text <- substr(text, yaml_end + 1L, nchar(text))
+  } else {
+    text
+  }
 
   # don't include text in code chunks: https://regex101.com/#python
   text <- gsub("```\\{.+?\\}.+?```", "", text)
@@ -193,11 +200,9 @@ prep_text <- function(text){
 
   if(nchar(text) == 0){
     stop("You have not selected any text. Please select some text with the mouse and try again")
-  } else {
+  }
 
   return(text)
-
-  }
 
 }
 

--- a/man/text_stats.Rd
+++ b/man/text_stats.Rd
@@ -26,6 +26,8 @@ text_stats_fn_(text)
 Default is the current file (when working in RStudio) or the file being
 knit (when compiling with \code{knitr}).}
 
+\item{quiet}{Logical. Should task be performed quietly?}
+
 \item{text}{a character string of text, length of one}
 }
 \description{

--- a/man/wordcountaddin.Rd
+++ b/man/wordcountaddin.Rd
@@ -3,7 +3,6 @@
 \docType{package}
 \name{wordcountaddin}
 \alias{wordcountaddin}
-\alias{wordcountaddin-package}
 \title{wordcountaddin}
 \description{
 This packages is an addin for RStudio that will count the words and characters in a plain text document. It is designed for use with R markdown documents and will exclude YAML header content, code chunks and inline code from the counts. It also computes readability statistics so you can get an idea of how easy or difficult your text is to read.

--- a/tests/testthat/test_wordcountaddin.R
+++ b/tests/testthat/test_wordcountaddin.R
@@ -168,13 +168,13 @@ test_that("Word count is correct for rmd file", {
   the_rmd_file_stats <- text_stats(filename = test_path("test_wordcountaddin.Rmd"))
 
   expect_equal(the_rmd_file_stats[3],
-               "|Word count      |117         |116           |")
+               "|Word count      |106         |105           |")
   expect_equal(the_rmd_file_stats[4],
-               "|Character count |687         |687           |")
+               "|Character count |602         |602           |")
   expect_equal(the_rmd_file_stats[5],
-               "|Sentence count  |12          |Not available |")
+               "|Sentence count  |8           |Not available |")
   expect_equal(the_rmd_file_stats[6],
-               "|Reading time    |0.6 minutes |0.6 minutes   |")
+               "|Reading time    |0.5 minutes |0.5 minutes   |")
 })
 
 
@@ -229,7 +229,7 @@ test_that("Word count is a single integer for a Rmd file when using word_count",
   the_rmd_word_count <- word_count(filename = test_path("test_wordcountaddin.Rmd"))
 
   expect_equal(the_rmd_word_count,
-               117L)
+               106L)
 })
 
 test_that("We can handle very long strings, like citation keys", {


### PR DESCRIPTION
The solution for fixing the YAML issue is a little more brute force than I thought it would need to be, but I think it should work well. It basically enforces a check to ensure the first "---" pattern detected is the opening line in the file (i.e. there is indeed a YAML front matter), the next "---" pattern is used to enclose the YAML (`yaml_end`), and the entire YAML block is removed.

The existing units tests cover the updated code; I just needed to update the test expectations.