### PR TITLE
Better figure caption handling

### DIFF
--- a/R/hello.R
+++ b/R/hello.R
@@ -174,7 +174,7 @@ prep_text <- function(text){
   # how to do this? %%
 
   # don't include images with captions
-  text <- gsub("!\\[.+?\\)", "", text)
+  text <- gsub("!\\[.+?\\]", "", text)
 
   # don't include inline markdown URLs
   text <- gsub("\\(http.+?\\)", "", text)

--- a/R/hello.R
+++ b/R/hello.R
@@ -174,7 +174,8 @@ prep_text <- function(text){
   # how to do this? %%
 
   # don't include images with captions
-  text <- gsub("!\\[.+?\\]", "", text)
+  text <- gsub("!\\[.+?\\]\\(.+?\\)\\{.+?\\}", "", text)
+  text <- gsub("!\\[.+?\\]\\(.+?\\)", "", text)
 
   # don't include inline markdown URLs
   text <- gsub("\\(http.+?\\)", "", text)


### PR DESCRIPTION
This PR patches a bug in how image captions were handled. The regex was written to exclude text between an opening square bracket and a round bracket. However figure captions in my field are very long and frequently contain round brackets, so the figure captions were not being completely removed. This update removes the full figure caption and the path to the figure file, as well as any figure parameters specified in curly braces. 

Thanks for an excellent tool!